### PR TITLE
BadObject Issue

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -152,6 +152,8 @@ class Repository(object):
             return None
         except git.GitCommandError: # 0.3.x
             return None
+        except git.BadObject: # 0.3.2
+            return None
 
     @synchronized('lock')
     def get_commit_id(self, commit):


### PR DESCRIPTION
I noticed the issue explained in #17 for myself while i was trying to get your plugin running. I noticed that (propably since GitPython 0.3.2) repo.commit(..) raises BadObject if its argument will be an invalid sha sum. It's obviously just a tiny fix. Anyway, thanks for your great work resulting in quite a handy plugin for daily use :)

Cheers,
Ivo
